### PR TITLE
Added option to always display hostname next to user in prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,8 @@ The next segments have (sub)settings of their own:
     background colors.
     - `TRUELINE_USER_SHOW_IP_SSH=false`: boolean variable that determines whether to
     show the ip address or hostname in a ssh connection.
+    - `TRUELINE_USER_ALWAYS_SHOW_HOSTNAME=false`: boolean variable that determines 
+    whether to always show the ip address or hostname (not just in a ssh connection).
 - working_dir:
     - `TRUELINE_WORKING_DIR_SPACE_BETWEEN_PATH_SEPARATOR=true`: boolean variable that
     determines whether to add (or not) a space before and after the path separator.

--- a/trueline.sh
+++ b/trueline.sh
@@ -86,16 +86,9 @@ _trueline_user_segment() {
         bg_color=${TRUELINE_USER_ROOT_COLORS[1]}
     fi
     local has_ssh="$(_trueline_has_ssh)"
-
-    # If it's an ssh connection add the ssh symbol in front of the username
-    #----------------------------------------------------------------------
     if [[ -n "$has_ssh" ]]; then 
         user="${TRUELINE_SYMBOLS[ssh]} $user"
     fi
-
-    # In case of an ssh connection or if the option for always displaying the hostname
-    # is set add an "@" to the username before adding IP address or hostname
-    #---------------------------------------------------------------------------------
     if [[ -n "$has_ssh" ]] || [[ "$TRUELINE_USER_ALWAYS_SHOW_HOSTNAME" = true ]]; then
         user+="@"
         if [ "$TRUELINE_USER_SHOW_IP_SSH" = true ]; then
@@ -530,8 +523,6 @@ fi
 if [[ -z "$TRUELINE_USER_SHOW_IP_SSH" ]]; then
     TRUELINE_USER_SHOW_IP_SSH=false
 fi
-# Option to always display the hostname or IP - not just when connected via ssh
-#------------------------------------------------------------------------------
 if [[ -z "$TRUELINE_USER_ALWAYS_SHOW_HOSTNAME" ]]; then
     TRUELINE_USER_ALWAYS_SHOW_HOSTNAME=false
 fi

--- a/trueline.sh
+++ b/trueline.sh
@@ -86,14 +86,25 @@ _trueline_user_segment() {
         bg_color=${TRUELINE_USER_ROOT_COLORS[1]}
     fi
     local has_ssh="$(_trueline_has_ssh)"
-    if [[ -n "$has_ssh" ]]; then
-        user="${TRUELINE_SYMBOLS[ssh]} $user@"
+
+    # If it's an ssh connection add the ssh symbol in front of the username
+    #----------------------------------------------------------------------
+    if [[ -n "$has_ssh" ]]; then 
+        user="${TRUELINE_SYMBOLS[ssh]} $user"
+    fi
+
+    # In case of an ssh connection or if the option for always displaying the hostname
+    # is set add an "@" to the username before adding IP address or hostname
+    #---------------------------------------------------------------------------------
+    if [[ -n "$has_ssh" ]] || [[ "$TRUELINE_USER_ALWAYS_SHOW_HOSTNAME" = true ]]; then
+        user+="@"
         if [ "$TRUELINE_USER_SHOW_IP_SSH" = true ]; then
             user+="$(_trueline_ip_address)"
         else
             user+="$HOSTNAME"
         fi
     fi
+
     local segment="$(_trueline_separator)"
     segment+="$(_trueline_content "$fg_color" "$bg_color" "$font_style" " $user ")"
     PS1+="$segment"
@@ -518,6 +529,11 @@ if [[ -z "$TRUELINE_USER_ROOT_COLORS" ]]; then
 fi
 if [[ -z "$TRUELINE_USER_SHOW_IP_SSH" ]]; then
     TRUELINE_USER_SHOW_IP_SSH=false
+fi
+# Option to always display the hostname or IP - not just when connected via ssh
+#------------------------------------------------------------------------------
+if [[ -z "$TRUELINE_USER_ALWAYS_SHOW_HOSTNAME" ]]; then
+    TRUELINE_USER_ALWAYS_SHOW_HOSTNAME=false
 fi
 
 # Working dir

--- a/trueline.sh
+++ b/trueline.sh
@@ -97,7 +97,6 @@ _trueline_user_segment() {
             user+="$HOSTNAME"
         fi
     fi
-
     local segment="$(_trueline_separator)"
     segment+="$(_trueline_content "$fg_color" "$bg_color" "$font_style" " $user ")"
     PS1+="$segment"


### PR DESCRIPTION
#### Reference Issues
I'm working on my local computer with several virtual machines. As long as I'm not connected to the VM with ssh only the username is displayed and I have to lookup on which machine I'm working right now.

#### What does this implement/fix?
I added an additional option to let the user choose if the hostname (or IP address) is always displayed or just in case of an ssh connection

#### Any other comments
Thanks for your great work! I really like your slim and powerful prompt design!
Cheers, 
Michael