### PR TITLE
Added option for raw prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,11 @@ The next segments have (sub)settings of their own:
     directory is shortened to `TRUELINE_WORKING_DIR_ABBREVIATE_PARENT_DIRS_LENGTH`.
     - `TRUELINE_WORKING_DIR_ABBREVIATE_PARENT_DIRS_LENGTH=1`: length of each parent
         directory when `TRUELINE_WORKING_DIR_ABBREVIATE_PARENT_DIRS` is enabled.
+- prompt:
+    - `TRUELINE_SHOW_TRAILING_SEPARATOR=true`: boolean variable that determines 
+    whether to show/hide the segment separator ''. This option should be set to
+    false _only_ with the newline segment when one wants to have a bare/raw prompt 
+    on default terminal background. 
 
 #### External
 

--- a/trueline.sh
+++ b/trueline.sh
@@ -454,12 +454,10 @@ _trueline_prompt_command() {
     done
 
     _trueline_vimode_segment
-    # Provide an option for a segment-enclosed prompt or a raw prompt
-    if [ "$TRUELINE_NEWLINE_PROMPT_WITHOUT_SEGMENT" = true ]; then
-        # Use default_fg and default_bg with this option for a raw prompt
-        PS1+=$(_trueline_content "$_last_color" default_bg bold)
-    else
-        PS1+=$(_trueline_content "$_last_color" default_bg bold "${TRUELINE_SYMBOLS[segment_separator]}")
+    PS1+=$(_trueline_content "$_last_color" default_bg bold)
+    # Provide an option to show/remove the trailing separator
+    if [ "$TRUELINE_SHOW_TRAILING_SEPARATOR" = true ]; then
+        PS1+="${TRUELINE_SYMBOLS[segment_separator]}"
     fi
     PS1+=" " # non-breakable space
     _trueline_continuation_prompt
@@ -590,13 +588,17 @@ fi
 # Working dir
 if [[ -z "$TRUELINE_WORKING_DIR_SPACE_BETWEEN_PATH_SEPARATOR" ]]; then
     TRUELINE_WORKING_DIR_SPACE_BETWEEN_PATH_SEPARATOR=true
-
 fi
 if [[ -z "$TRUELINE_WORKING_DIR_ABBREVIATE_PARENT_DIRS" ]]; then
     TRUELINE_WORKING_DIR_ABBREVIATE_PARENT_DIRS=false
 fi
 if [[ -z "$TRUELINE_WORKING_DIR_ABBREVIATE_PARENT_DIRS_LENGTH" ]]; then
     TRUELINE_WORKING_DIR_ABBREVIATE_PARENT_DIRS_LENGTH=1
+fi
+
+# Prompt
+if [[ -z "$TRUELINE_SHOW_TRAILING_SEPARATOR" ]]; then
+    TRUELINE_SHOW_TRAILING_SEPARATOR=true
 fi
 
 #----------------+

--- a/trueline.sh
+++ b/trueline.sh
@@ -454,7 +454,13 @@ _trueline_prompt_command() {
     done
 
     _trueline_vimode_segment
-    PS1+=$(_trueline_content "$_last_color" default_bg bold "${TRUELINE_SYMBOLS[segment_separator]}")
+    # Provide an option for a segment-enclosed prompt or a raw prompt
+    if [ "$TRUELINE_NEWLINE_PROMPT_WITHOUT_SEGMENT" = true ]; then
+        # Use default_fg and default_bg with this option for a raw prompt
+        PS1+=$(_trueline_content "$_last_color" default_bg bold)
+    else
+        PS1+=$(_trueline_content "$_last_color" default_bg bold "${TRUELINE_SYMBOLS[segment_separator]}")
+    fi
     PS1+=" " # non-breakable space
     _trueline_continuation_prompt
 


### PR DESCRIPTION
I use the newline option, and prefer a "raw" prompt on the second line as opposed to one wrapped in a segment with non-default background and segment separator. Perhaps there may be others who have this preference.

In order to enable this choice I added a TRUELINE_NEWLINE_PROMPT_WITHOUT_SEGMENT option and the logic to process the choices. If the option is "true", then the segment separator is removed and the user can enable the "newline" prompt segment with default_bg and default_fg in order to get the raw prompt on the default terminal background. If the option is false, then the "newline" segment operates as it does now with a segment-enclosed prompt character on the second line.