### PR TITLE
Avoid overwriting existing PROMPT_COMMAND

### DIFF
--- a/trueline.sh
+++ b/trueline.sh
@@ -285,7 +285,10 @@ _trueline_working_dir_segment() {
 }
 
 _trueline_bg_jobs_segment() {
-    local bg_jobs=$(jobs -p | wc -l | sed 's/^ *//')
+    # Note: We clear terminated foreground job information by first
+    #   calling `jobs &>/dev/null' and then obtain the information of
+    #   the currently running jobs by `jobs -p'.
+    local bg_jobs=$(jobs &>/dev/null; jobs -p | wc -l | sed 's/^ *//')
     if [[ ! "$bg_jobs" -eq 0 ]]; then
         local fg_color="$1"
         local bg_color="$2"

--- a/trueline.sh
+++ b/trueline.sh
@@ -447,7 +447,7 @@ _trueline_continuation_prompt() {
 }
 
 _trueline_prompt_command() {
-    _exit_status="$?"
+    local _exit_status="$?"
     PS1=""
 
     local segment_def=
@@ -470,7 +470,10 @@ _trueline_prompt_command() {
     unset _first_color_bg
     unset _first_font_style
     unset _last_color
-    unset _exit_status
+
+    # Note: we reset the exit status to the original value for the subsequent
+    # commands in PROMPT_COMMAND.
+    return "$_exit_status"
 }
 
 #---------------+
@@ -607,9 +610,10 @@ fi
 #----------------+
 # PROMPT_COMMAND |
 #----------------+
-# Backup old prompt command first
-if [ -z "$_PROMPT_COMMAND_OLD" ]; then
-    _PROMPT_COMMAND_OLD="$PROMPT_COMMAND"
+if ((BASH_VERSINFO[0] > 5 || BASH_VERSINFO[0] == 5 && BASH_VERSINFO[1] >= 1)); then
+  # Bash 5.1 and above supports the PROMPT_COMMAND array
+  PROMPT_COMMAND=${PROMPT_COMMAND-}
+  PROMPT_COMMAND+=(_trueline_prompt_command)
+else
+  PROMPT_COMMAND="_trueline_prompt_command${PROMPT_COMMAND:+;$PROMPT_COMMAND}"
 fi
-unset PROMPT_COMMAND
-PROMPT_COMMAND=_trueline_prompt_command


### PR DESCRIPTION
Fixes #43 

There seems to be an existing report #43 by another user, but I have also faced a problem with `trueline` for its behavior overwriting `PROMPT_COMMAND`. This PR fixes the problem.

### Problem

The current setup of `trueline` overwrites the existing value of `PROMPT_COMMAND`, so the setups by other plugins sourced before `trueline` are all disabled.

Bash 5.1 introduced the array `PROMPT_COMMAND` to resolve the conflicting `PROMPT_COMMAND`, but `trueline` even completely breaks this new Bash 5.1 feature by `unset PROMPT_COMMAND`. With Bash 5.1+, the plugins are supposed to add its `PROMPT_COMMAND` by e.g. `PROMPT_COMMAND+=(_plugin_specific_prompt_command)` keeping the existing array elements as is. However, the current `trueline` removes all the other elements by unsetting the entire array by `unset PROMPT_COMMAND`.

<!-- All typical bash frameworks like bash-preexec, oh-my-bash, and bash-it preserve the values of `PROMPT_COMMAND` for other Bash configurations. The current behavior of `trueline` is anomalous. -->

### Solution

With Bash 5.1+, we may just use `PROMPT_COMMAND+=(_trueline_prompt_command)`. To protect it from some older plugins that does not support Bash 5.1+, we can optionally prepend `PROMPT_COMMAND=${PROMPT_COMMAND-}` as suggested by Martijn in the Bash mailing list [1].

- [1] https://lists.gnu.org/archive/html/bug-bash/2020-08/msg00132.html

With Bash 5.0 and below, we can prepend `_trueline_prompt_command` in the existing value of `PROMPT_COMMAND`.
