### PR TITLE
Add distro icon segment for diverse Linux flavors in True Line

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ by default):
 | user         | enabled  | username and host (conditional on ssh status) |
 | venv         | enabled  | Python virtual environment                    |
 | working_dir  | enabled  | current working directory                     |
-| distro_icon  | disabled | current linux distribution icon               |
+| distro_icon  | disabled | current Linux distribution icon               |
 
 but more segments can be easily added (see [Extensions](#extensions)).
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,16 @@
 # Trueline: Bash Powerline Style Prompt with True Color Support
 
 <!--toc:start-->
-- [Installation](#installation)
-- [Customization](#customization)
-  - [Colors](#colors)
-  - [Segments](#segments)
-  - [Symbols](#symbols)
-  - [Options](#options)
-    - [Intra-segment](#intra-segment)
-    - [External](#external)
-  - [Extensions](#extensions)
+- [Trueline: Bash Powerline Style Prompt with True Color Support](#trueline-bash-powerline-style-prompt-with-true-color-support)
+  - [Installation](#installation)
+  - [Customization](#customization)
+    - [Colors](#colors)
+    - [Segments](#segments)
+    - [Symbols](#symbols)
+    - [Options](#options)
+      - [Intra-segment](#intra-segment)
+      - [External](#external)
+    - [Extensions](#extensions)
 <!--toc:end-->
 
 Trueline is a fast and extensible [Powerline](https://github.com/powerline/powerline)
@@ -179,6 +180,7 @@ by default):
 | user         | enabled  | username and host (conditional on ssh status) |
 | venv         | enabled  | Python virtual environment                    |
 | working_dir  | enabled  | current working directory                     |
+| distro_icon  | disabled | current linux distribution icon               |
 
 but more segments can be easily added (see [Extensions](#extensions)).
 

--- a/trueline.sh
+++ b/trueline.sh
@@ -446,12 +446,12 @@ _trueline_cmd_duration_segment() {
 }
 
 _trueline_distro_icon_segment() {
-    case "$(cat /etc/os-release | grep ^ID= )" in
+    case "$( grep ^ID= /etc/os-release )" in
         *ubuntu*) distro_icon=" " ;;
         *fedora*) distro_icon=" " ;;
         *debian*) distro_icon=" " ;;
         *arch*) distro_icon=" " ;;
-        *) distro_icon="${TRUELINE_SYMBOLS[empty_distribution]} " ;;
+        *) distro_icon="${TRUELINE_SYMBOLS[distro_icon]} " ;;
     esac
     
     local fg_color="$1"
@@ -537,7 +537,7 @@ if [[ "${#TRUELINE_SEGMENTS[@]}" -eq 0 ]]; then
         'working_dir,mono,cursor_grey,normal'
         'read_only,black,orange,bold'
         'bg_jobs,black,orange,bold'
-        'exit_status,black,red,bold'        
+        'exit_status,black,red,bold' 
         # 'cmd_duration,black,grey,normal'
         # 'newline,black,orange,bold'
         # 'distro_icon,black,green,normal'
@@ -568,7 +568,7 @@ declare -A TRUELINE_SYMBOLS_DEFAULT=(
     [working_dir_folder]=''
     [working_dir_home]=''
     [working_dir_separator]=''
-    [empty_distribution]=' '
+    [distro_icon]=' '
 )
 if [[ "${#TRUELINE_SYMBOLS[@]}" -eq 0 ]]; then
     declare -A TRUELINE_SYMBOLS=()

--- a/trueline.sh
+++ b/trueline.sh
@@ -462,7 +462,6 @@ _trueline_distro_icon_segment() {
     segment+="$(_trueline_content "$fg_color" "$bg_color" "$font_style" " $distro_icon ")"
     PS1+="$segment"
     _trueline_record_colors "$fg_color" "$bg_color" "$font_style"
-
 }
 
 #-------------+

--- a/trueline.sh
+++ b/trueline.sh
@@ -451,7 +451,6 @@ _trueline_distro_icon_segment() {
         *fedora*) distro_icon=" " ;;
         *debian*) distro_icon=" " ;;
         *arch*) distro_icon=" " ;;
-        Linux*) distro_icon=" " ;;
         *) distro_icon="${TRUELINE_SYMBOLS[empty_distribution]} " ;;
     esac
     

--- a/trueline.sh
+++ b/trueline.sh
@@ -445,6 +445,34 @@ _trueline_cmd_duration_segment() {
     fi
 }
 
+_trueline_distro_icon_segment() {
+    
+    set_distribution_icon() {
+        case "$(uname -a)" in
+            *ubuntu*) distro_icon=" " ;;
+            *fedora*) distro_icon=" " ;;
+            *debian*) distro_icon=" " ;;
+            *arch*) distro_icon=" " ;;
+            *) distro_icon=" " ;;
+        esac
+    }
+
+    # Call the set_distribution_icon function to set the distro_icon.
+    set_distribution_icon
+
+    local some_content="$distro_icon"
+
+    if [[ -n "$some_content" ]]; then
+        local fg_color="$1"
+        local bg_color="$2"
+        local font_style="$3"
+        local segment="$(_trueline_separator)"
+        segment+="$(_trueline_content "$fg_color" "$bg_color" "$font_style" " $some_content ")"
+        PS1+="$segment"
+        _trueline_record_colors "$fg_color" "$bg_color" "$font_style"
+    fi
+}
+
 #-------------+
 # PS1 and PS2 |
 #-------------+

--- a/trueline.sh
+++ b/trueline.sh
@@ -537,7 +537,7 @@ if [[ "${#TRUELINE_SEGMENTS[@]}" -eq 0 ]]; then
         'working_dir,mono,cursor_grey,normal'
         'read_only,black,orange,bold'
         'bg_jobs,black,orange,bold'
-        'exit_status,black,red,bold' 
+        'exit_status,black,red,bold'
         # 'cmd_duration,black,grey,normal'
         # 'newline,black,orange,bold'
         # 'distro_icon,black,green,normal'

--- a/trueline.sh
+++ b/trueline.sh
@@ -447,22 +447,17 @@ _trueline_cmd_duration_segment() {
 
 _trueline_distro_icon_segment() {
     
-    set_distribution_icon() {
-        case "$(uname -a)" in
-            *ubuntu*) distro_icon=" " ;;
-            *fedora*) distro_icon=" " ;;
-            *debian*) distro_icon=" " ;;
-            *arch*) distro_icon=" " ;;
-            Linux*) distro_icon=" " ;;
-            *) distro_icon="${TRUELINE_SYMBOLS[empty_distribution]} " ;;
-        esac
-    }
-
-    # Call the set_distribution_icon function to set the distro_icon.
-    set_distribution_icon
-
+    
+    case "$(uname -a)" in
+        *ubuntu*) distro_icon=" " ;;
+        *fedora*) distro_icon=" " ;;
+        *debian*) distro_icon=" " ;;
+        *arch*) distro_icon=" " ;;
+        Linux*) distro_icon=" " ;;
+        *) distro_icon="${TRUELINE_SYMBOLS[empty_distribution]} " ;;
+    esac
+    
     local choosed_distribution_icon="$distro_icon"
-
     
     local fg_color="$1"
     local bg_color="$2"
@@ -548,10 +543,10 @@ if [[ "${#TRUELINE_SEGMENTS[@]}" -eq 0 ]]; then
         'working_dir,mono,cursor_grey,normal'
         'read_only,black,orange,bold'
         'bg_jobs,black,orange,bold'
-        'exit_status,black,red,bold'
-        # 'distro_icon, black, green, normal'
+        'exit_status,black,red,bold'        
         # 'cmd_duration,black,grey,normal'
         # 'newline,black,orange,bold'
+        # 'distro_icon, black, green, normal'
     )
 fi
 

--- a/trueline.sh
+++ b/trueline.sh
@@ -457,13 +457,11 @@ _trueline_distro_icon_segment() {
         *) distro_icon="${TRUELINE_SYMBOLS[empty_distribution]} " ;;
     esac
     
-    local choosed_distribution_icon="$distro_icon"
-    
     local fg_color="$1"
     local bg_color="$2"
     local font_style="$3"
     local segment="$(_trueline_separator)"
-    segment+="$(_trueline_content "$fg_color" "$bg_color" "$font_style" " $choosed_distribution_icon ")"
+    segment+="$(_trueline_content "$fg_color" "$bg_color" "$font_style" " $distro_icon ")"
     PS1+="$segment"
     _trueline_record_colors "$fg_color" "$bg_color" "$font_style"
 
@@ -546,7 +544,7 @@ if [[ "${#TRUELINE_SEGMENTS[@]}" -eq 0 ]]; then
         'exit_status,black,red,bold'        
         # 'cmd_duration,black,grey,normal'
         # 'newline,black,orange,bold'
-        # 'distro_icon, black, green, normal'
+        # 'distro_icon,black,green,normal'
     )
 fi
 
@@ -576,7 +574,6 @@ declare -A TRUELINE_SYMBOLS_DEFAULT=(
     [working_dir_separator]=''
     [empty_distribution]=' '
 )
-
 if [[ "${#TRUELINE_SYMBOLS[@]}" -eq 0 ]]; then
     declare -A TRUELINE_SYMBOLS=()
 fi

--- a/trueline.sh
+++ b/trueline.sh
@@ -453,24 +453,25 @@ _trueline_distro_icon_segment() {
             *fedora*) distro_icon=" " ;;
             *debian*) distro_icon=" " ;;
             *arch*) distro_icon=" " ;;
-            *) distro_icon=" " ;;
+            Linux*) distro_icon=" " ;;
+            *) distro_icon="${TRUELINE_SYMBOLS[empty_distribution]} " ;;
         esac
     }
 
     # Call the set_distribution_icon function to set the distro_icon.
     set_distribution_icon
 
-    local some_content="$distro_icon"
+    local choosed_distribution_icon="$distro_icon"
 
-    if [[ -n "$some_content" ]]; then
-        local fg_color="$1"
-        local bg_color="$2"
-        local font_style="$3"
-        local segment="$(_trueline_separator)"
-        segment+="$(_trueline_content "$fg_color" "$bg_color" "$font_style" " $some_content ")"
-        PS1+="$segment"
-        _trueline_record_colors "$fg_color" "$bg_color" "$font_style"
-    fi
+    
+    local fg_color="$1"
+    local bg_color="$2"
+    local font_style="$3"
+    local segment="$(_trueline_separator)"
+    segment+="$(_trueline_content "$fg_color" "$bg_color" "$font_style" " $choosed_distribution_icon ")"
+    PS1+="$segment"
+    _trueline_record_colors "$fg_color" "$bg_color" "$font_style"
+
 }
 
 #-------------+
@@ -548,6 +549,7 @@ if [[ "${#TRUELINE_SEGMENTS[@]}" -eq 0 ]]; then
         'read_only,black,orange,bold'
         'bg_jobs,black,orange,bold'
         'exit_status,black,red,bold'
+        # 'distro_icon, black, green, normal'
         # 'cmd_duration,black,grey,normal'
         # 'newline,black,orange,bold'
     )
@@ -577,7 +579,9 @@ declare -A TRUELINE_SYMBOLS_DEFAULT=(
     [working_dir_folder]=''
     [working_dir_home]=''
     [working_dir_separator]=''
+    [empty_distribution]=' '
 )
+
 if [[ "${#TRUELINE_SYMBOLS[@]}" -eq 0 ]]; then
     declare -A TRUELINE_SYMBOLS=()
 fi

--- a/trueline.sh
+++ b/trueline.sh
@@ -446,7 +446,7 @@ _trueline_cmd_duration_segment() {
 }
 
 _trueline_distro_icon_segment() {
-    case "$(uname -a)" in
+    case "$(cat /etc/os-release | grep ^ID= )" in
         *ubuntu*) distro_icon=" " ;;
         *fedora*) distro_icon=" " ;;
         *debian*) distro_icon=" " ;;

--- a/trueline.sh
+++ b/trueline.sh
@@ -446,8 +446,6 @@ _trueline_cmd_duration_segment() {
 }
 
 _trueline_distro_icon_segment() {
-    
-    
     case "$(uname -a)" in
         *ubuntu*) distro_icon=" " ;;
         *fedora*) distro_icon=" " ;;

--- a/trueline.sh
+++ b/trueline.sh
@@ -446,7 +446,7 @@ _trueline_cmd_duration_segment() {
 }
 
 _trueline_distro_icon_segment() {
-    case "$( grep ^ID= /etc/os-release )" in
+    case "$(grep ^ID= /etc/os-release)" in
         *ubuntu*) distro_icon=" " ;;
         *fedora*) distro_icon=" " ;;
         *debian*) distro_icon=" " ;;


### PR DESCRIPTION
## Description

This pull request introduces a new function `_trueline_distro_icon_segment` to the True Line prompt, enhancing its ability to display distinct icons for various Linux distributions.

## Details

The function dynamically sets icons for Ubuntu, Fedora, Debian, and Arch, with a generic icon for other Linux distributions. This feature allows users to easily identify their current operating system environment directly in the shell prompt, improving user experience and providing quick visual signal.

---

I welcome any feedback or suggestions for improvement and look forward to your thoughts on integrating this feature into the main codebase.

