### PR TITLE
Fix working dir segment issues

### DIFF
--- a/trueline.sh
+++ b/trueline.sh
@@ -256,7 +256,7 @@ _trueline_working_dir_segment() {
         wd_separator=" $wd_separator "
     fi
 
-    local p="${PWD/$HOME/${TRUELINE_SYMBOLS[working_dir_home]}}"
+    local p="${PWD/#$HOME/${TRUELINE_SYMBOLS[working_dir_home]}}"
     local arr=
     IFS='/' read -r -a arr <<< "$p"
     local path_size="${#arr[@]}"
@@ -269,7 +269,7 @@ _trueline_working_dir_segment() {
             if [[ "$TRUELINE_WORKING_DIR_ABBREVIATE_PARENT_DIRS" = true ]]; then
                 p=$(echo "$p" | sed -r "s:([^/]{,$TRUELINE_WORKING_DIR_ABBREVIATE_PARENT_DIRS_LENGTH})[^/]*/:\1/:g")
             else
-                p="${TRUELINE_SYMBOLS[working_dir_folder]}/"$(echo "$p" | rev | cut -d '/' -f-3 | rev)
+                p="${TRUELINE_SYMBOLS[working_dir_folder]}/"$(echo "$p" | awk -F'/' '{n=NF; print $(n-2)"/"$(n-1)"/"$n}')
             fi
         fi
         local curr=$(basename "$p")


### PR DESCRIPTION
**Changes**
- Trueline home symbol now only replaces $HOME when it is at the beginning of the path, fixes issue where "/mnt/backup/1234/home/myuser" would replace to "/mnt/backup/1234 :house:"
- Fixed issue where on some terminal emulators (vscode), reversing trueline symbols would result in `rev: invalid or incomplete multibyte or wide character`, modified to use awk instead of rev

Let me know if there's anything else I can do to help!